### PR TITLE
feat: Add drag-and-drop for map markers

### DIFF
--- a/components/interactive-map.tsx
+++ b/components/interactive-map.tsx
@@ -184,6 +184,17 @@ export function InteractiveMap() {
     [isOptimizing],
   )
 
+  const handleStopMove = useCallback(
+    (id: string, lat: number, lng: number) => {
+      if (isOptimizing) return
+      setStops((prev) =>
+        prev.map((stop) => (stop.id === id ? { ...stop, lat, lng } : stop))
+      )
+      setError(null)
+    },
+    [isOptimizing],
+  )
+
   const clearStops = useCallback(() => {
     if (isOptimizing) return
     setStops((prev) => prev.filter((stop) => stop.isDepot))
@@ -504,6 +515,7 @@ export function InteractiveMap() {
                   selectedRoute={selectedRoute}
                   onMapClick={handleMapClick}
                   onStopRemove={removeStop}
+                  onStopMove={handleStopMove}
                   isOptimizing={isOptimizing}
                   isDepotMode={isDepotMode}
                   onMapReady={(map) => (mapRef.current = map)}

--- a/components/leaflet-map.tsx
+++ b/components/leaflet-map.tsx
@@ -9,6 +9,7 @@ interface LeafletMapProps {
   selectedRoute: RouteResult | null
   onMapClick: (lat: number, lng: number) => void
   onStopRemove: (id: string) => void
+  onStopMove: (id: string, lat: number, lng: number) => void;
   isOptimizing: boolean
   isDepotMode?: boolean // Added depot mode prop
   onMapReady?: (map: any) => void;
@@ -21,6 +22,7 @@ export function LeafletMap({
   selectedRoute,
   onMapClick,
   onStopRemove,
+  onStopMove,
   isOptimizing,
   isDepotMode = false, // Added depot mode with default value
   onMapReady,
@@ -134,7 +136,10 @@ export function LeafletMap({
         iconAnchor: [20, 35],
       })
 
-      const marker = L.marker([stop.lat, stop.lng], { icon }).addTo(map)
+      const marker = L.marker([stop.lat, stop.lng], {
+        icon,
+        draggable: !isDepot && !isOptimizing,
+       }).addTo(map)
 
       // Handle remove button click
       if (!isDepot && !isOptimizing) {
@@ -144,6 +149,11 @@ export function LeafletMap({
             onStopRemove(stop.id)
           }
         })
+
+        marker.on('dragend', (e: any) => {
+          const { lat, lng } = e.target.getLatLng();
+          onStopMove(stop.id, lat, lng);
+        });
       }
 
       markersRef.current.push(marker)


### PR DESCRIPTION
This commit adds the ability for users to drag and drop destination markers on the map to update their locations. This provides a more fluid and intuitive way to adjust the route.

- Markers for stops (not the depot) are now draggable.
- When a marker is dropped, its new coordinates are saved to the state, and the map is updated.