### PR TITLE
Fix(map): Prevent location points from disappearing after optimization

### DIFF
--- a/components/interactive-map.tsx
+++ b/components/interactive-map.tsx
@@ -39,6 +39,7 @@ export function InteractiveMap() {
     { id: "stop3", name: "Grocery Market", lat: 16.51, lng: 80.635 },
     { id: "stop4", name: "Restaurant", lat: 16.522, lng: 80.651 },
   ])
+  const [processedStops, setProcessedStops] = useState<DeliveryStop[]>(stops)
 
   const [isDepotMode, setIsDepotMode] = useState(false)
   const [searchQuery, setSearchQuery] = useState("")
@@ -253,6 +254,7 @@ export function InteractiveMap() {
 
       setRoutes(response.candidates)
       setSelectedRoute(response.candidates[response.bestIndex])
+      setProcessedStops(stops)
 
       // Clear status after delay
       setTimeout(() => {
@@ -303,6 +305,7 @@ export function InteractiveMap() {
 
       setRoutes(mockRoutes)
       setSelectedRoute(mockRoutes[0])
+      setProcessedStops(stops)
       setOptimizationProgress(0)
       setOptimizationStatus("")
     }
@@ -543,6 +546,7 @@ export function InteractiveMap() {
                   isDepotMode={isDepotMode}
                   onMapReady={(map) => (mapRef.current = map)}
                   searchedLocation={searchedLocation}
+                  stopsForRoutes={processedStops}
                 />
 
                 {/* Map Controls */}
@@ -755,7 +759,7 @@ export function InteractiveMap() {
 
       <div className="grid lg:grid-cols-2 gap-6">
         <ResultsVisualization routes={routes} selectedRoute={selectedRoute} />
-        <NavigationPanel stops={stops} selectedRoute={selectedRoute} />
+        <NavigationPanel stops={processedStops} selectedRoute={selectedRoute} />
       </div>
 
       {routes.length > 0 && (
@@ -770,7 +774,7 @@ export function InteractiveMap() {
             </p>
           </CardHeader>
           <CardContent>
-            <CarbonFootprintCalculator routes={routes} selectedRoute={selectedRoute} />
+            <CarbonFootprintCalculator routes={routes} selectedRoute={selectedRoute} stops={processedStops} />
           </CardContent>
         </Card>
       )}

--- a/components/leaflet-map.tsx
+++ b/components/leaflet-map.tsx
@@ -6,6 +6,7 @@ import type { DeliveryStop, RouteResult } from "@/lib/types"
 interface LeafletMapProps {
   stops: DeliveryStop[]
   routes: RouteResult[]
+  stopsForRoutes: DeliveryStop[]
   selectedRoute: RouteResult | null
   onMapClick: (lat: number, lng: number) => void
   onStopRemove: (id: string) => void
@@ -19,6 +20,7 @@ interface LeafletMapProps {
 export function LeafletMap({
   stops,
   routes,
+  stopsForRoutes,
   selectedRoute,
   onMapClick,
   onStopRemove,
@@ -215,7 +217,7 @@ export function LeafletMap({
         // Draw non-selected routes as straight lines
         const routeCoords = route.tour
           .map((stopIndex) => {
-            const stop = stops[stopIndex];
+            const stop = stopsForRoutes[stopIndex];
             return stop ? [stop.lat, stop.lng] : null;
           })
           .filter(Boolean);
@@ -235,8 +237,8 @@ export function LeafletMap({
 
       // For selected route, fetch and draw the real road path
       for (let i = 0; i < route.tour.length - 1; i++) {
-        const startStop = stops[route.tour[i]];
-        const endStop = stops[route.tour[i + 1]];
+        const startStop = stopsForRoutes[route.tour[i]];
+        const endStop = stopsForRoutes[route.tour[i + 1]];
 
         if (!startStop || !endStop) continue;
 
@@ -303,7 +305,7 @@ export function LeafletMap({
       if (!route.feasible || route.tour.length === 0) return;
       fetchAndDrawRoute(route);
     });
-  }, [routes, selectedRoute, stops, isLoaded]);
+  }, [routes, selectedRoute, stopsForRoutes, isLoaded]);
 
   const getRouteColor = (solver: "quantum" | "classical", name: string) => {
     if (solver === "quantum") return "#7B2CBF"


### PR DESCRIPTION
Introduced a race condition where the location markers on the interactive map would disappear after the route optimization process completed.

This was caused by a race condition where the list of stops could be modified by the user while an optimization request was in flight. When the results returned, the route data (which uses indices) would be inconsistent with the updated stop data, leading to rendering errors that caused the markers to be cleared but not redrawn.

The fix involves the following changes:

1.  A new state variable, `processedStops`, is introduced in `interactive-map.tsx` to hold a snapshot of the stops array at the time of the optimization request.

2.  This `processedStops` snapshot is now passed to the `LeafletMap` and `NavigationPanel` components.

3.  The route-drawing logic in `LeafletMap` is updated to use these `processedStops` for rendering the route polylines, while the user-facing markers continue to use the live `stops` state. This decouples the two and ensures data consistency.