### PR TITLE
feat: Add GitHub link and heading animation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { InteractiveMap } from "@/components/interactive-map"
 import { BenchmarkDashboard } from "@/components/benchmark-dashboard"
 import { EfficiencyComparison } from "@/components/efficiency-comparison"
 import { CarbonFootprintCalculator } from "@/components/carbon-footprint-calculator"
+import { AnimatedHeading } from "@/components/animated-heading"
 
 export default function HomePage() {
   return (
@@ -27,9 +28,11 @@ export default function HomePage() {
               <Button variant="ghost" size="sm">
                 Benchmarks
               </Button>
-              <Button variant="ghost" size="sm">
-                GitHub
-              </Button>
+              <a href="https://github.com/Premchandyadav369/QuantaPath" target="_blank" rel="noopener noreferrer">
+                <Button variant="ghost" size="sm">
+                  GitHub
+                </Button>
+              </a>
               <Button size="sm" className="bg-accent hover:bg-accent/90">
                 Try Now <ArrowRight className="w-4 h-4 ml-1" />
               </Button>
@@ -46,9 +49,9 @@ export default function HomePage() {
               <Zap className="w-4 h-4 mr-1" />
               Optimizing delivery routes at quantum speed
             </Badge>
-            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold mb-6 leading-tight">
+            <AnimatedHeading className="text-4xl sm:text-5xl lg:text-6xl font-bold mb-6 leading-tight">
               Quantum-Powered Path Optimization for <span className="text-accent">Smarter Deliveries</span>
-            </h1>
+            </AnimatedHeading>
             <p className="text-xl text-muted-foreground mb-8 leading-relaxed">
               Harness QAOA and hybrid computing to find optimal delivery routes in real time. Experience the future of
               logistics optimization today.
@@ -58,10 +61,12 @@ export default function HomePage() {
                 <MapPin className="w-5 h-5 mr-2" />
                 Try Demo
               </Button>
-              <Button size="lg" variant="outline">
-                <GitBranch className="w-5 h-5 mr-2" />
-                View GitHub
-              </Button>
+              <a href="https://github.com/Premchandyadav369/QuantaPath" target="_blank" rel="noopener noreferrer">
+                <Button size="lg" variant="outline">
+                  <GitBranch className="w-5 h-5 mr-2" />
+                  View GitHub
+                </Button>
+              </a>
             </div>
           </div>
 

--- a/components/animated-heading.tsx
+++ b/components/animated-heading.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import React, { useEffect, useRef } from "react"
+import anime from "animejs"
+
+interface AnimatedHeadingProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export const AnimatedHeading: React.FC<AnimatedHeadingProps> = ({ children, className }) => {
+  const ref = useRef<HTMLHeadingElement>(null)
+
+  useEffect(() => {
+    if (ref.current) {
+      anime({
+        targets: ref.current,
+        translateY: [-50, 0],
+        opacity: [0, 1],
+        easing: "easeOutExpo",
+        duration: 1400,
+      })
+    }
+  }, [])
+
+  return (
+    <h1 ref={ref} className={className} style={{ opacity: 0 }}>
+      {children}
+    </h1>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-toggle": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "latest",
+    "animejs": "^4.1.3",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -62,6 +63,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.9",
+    "@types/animejs": "^3.1.13",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: latest
         version: 1.2.8(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      animejs:
+        specifier: ^4.1.3
+        version: 4.1.3
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.0)
@@ -162,6 +165,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.9
         version: 4.1.9
+      '@types/animejs':
+        specifier: ^3.1.13
+        version: 3.1.13
       '@types/node':
         specifier: ^22
         version: 22.0.0
@@ -1477,6 +1483,9 @@ packages:
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
+  '@types/animejs@3.1.13':
+    resolution: {integrity: sha512-yWg9l1z7CAv/TKpty4/vupEh24jDGUZXv4r26StRkpUPQm04ztJaftgpto8vwdFs8SiTq6XfaPKCSI+wjzNMvQ==}
+
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
@@ -1691,6 +1700,9 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  animejs@4.1.3:
+    resolution: {integrity: sha512-4XzlIsQsku1ycSPzchxxT0N+ohEMZObG71nOSBBkZoV4sgQvtXa/qAANkFpTE6pegdV8JnIBZiB0LfdxNoRNMw==}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -4403,6 +4415,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/animejs@3.1.13': {}
+
   '@types/d3-array@3.2.1': {}
 
   '@types/d3-color@3.1.3': {}
@@ -4611,6 +4625,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  animejs@4.1.3: {}
 
   ansi-styles@4.3.0:
     dependencies:


### PR DESCRIPTION
- Wraps the 'GitHub' and 'View GitHub' buttons in anchor tags to redirect to the project's GitHub repository.
- Adds anime.js as a dependency to the project.
- Introduces an `AnimatedHeading` component that uses anime.js to apply a fade-in and slide-up animation to the main heading.
- Replaces the static `h1` tag on the homepage with the new `AnimatedHeading` component to improve the frontend visuals.