### PR TITLE
feat: Add Excel/JSON import and export functionality with geocoding

### DIFF
--- a/components/advanced-parameter-controls.tsx
+++ b/components/advanced-parameter-controls.tsx
@@ -11,7 +11,7 @@ import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Settings, Zap, BarChart3, Info, Download, Share2, RotateCcw, Upload } from "lucide-react"
+import { Settings, Zap, BarChart3, Info, Download, Share2, RotateCcw, Upload, FileJson } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
 interface QuantumParams {
@@ -46,6 +46,7 @@ interface AdvancedParameterControlsProps {
   isOptimizing: boolean
   onImportStops: (file: File) => void
   onExportStops: () => void
+  onExportStopsJson: () => void
 }
 
 export function AdvancedParameterControls({
@@ -59,6 +60,7 @@ export function AdvancedParameterControls({
   isOptimizing,
   onImportStops,
   onExportStops,
+  onExportStopsJson,
 }: AdvancedParameterControlsProps) {
   const [activeTab, setActiveTab] = useState("quantum")
 
@@ -145,6 +147,14 @@ export function AdvancedParameterControls({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Export stops to Excel</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="sm" variant="outline" onClick={onExportStopsJson} disabled={isOptimizing}>
+                    <FileJson className="w-4 h-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Export stops to JSON</TooltipContent>
               </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/dev.log
+++ b/dev.log
@@ -1,3 +1,11 @@
 
 > my-v0-project@0.1.0 dev /app
 > next dev
+
+   ▲ Next.js 15.2.4
+   - Local:        http://localhost:3001
+   - Network:      http://192.168.0.2:3001
+   - Environments: .env.local
+
+ ✓ Starting...
+ ✓ Ready in 4.7s

--- a/lib/services/api-client.ts
+++ b/lib/services/api-client.ts
@@ -32,6 +32,23 @@ export class ApiClient {
     return response.json()
   }
 
+  async geocode(address: string): Promise<any[]> {
+    const response = await fetch(`${this.baseUrl}/api/geocode`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ address }),
+    })
+
+    if (!response.ok) {
+      const error = await response.json()
+      throw new Error(error.error || "Failed to geocode address")
+    }
+
+    return response.json()
+  }
+
   async optimizeRoutes(request: OptimizationRequest): Promise<OptimizationResponse> {
     const response = await fetch(`${this.baseUrl}/api/optimize`, {
       method: "POST",


### PR DESCRIPTION
This commit introduces the ability for users to import and export stops using Excel and JSON files.

- Adds the `xlsx` library to handle Excel file operations.
- Modifies the `AdvancedParameterControls` component to include "Import Stops", "Export Stops", and "Export Stops to JSON" buttons.
- Implements the `handleImportStops` function in `InteractiveMap` to parse uploaded Excel files and update the map with the new stops. This function can handle both addresses (which are geocoded) and latitude/longitude coordinates.
- Implements the `handleExportStops` and `handleExportStopsJson` functions in `InteractiveMap` to export the current stops to an Excel or JSON file.
- Adds a `geocode` method to the `ApiClient` to support geocoding addresses from imported Excel files.